### PR TITLE
refactor(hci): replace uv_hrtime with std chrono and remove libuv dependency

### DIFF
--- a/src/BluetoothHciL2Socket.cpp
+++ b/src/BluetoothHciL2Socket.cpp
@@ -3,7 +3,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <uv.h>
 #include <stdexcept>
 
 #include "BluetoothHciL2Socket.h"

--- a/src/BluetoothHciSocket.cpp
+++ b/src/BluetoothHciSocket.cpp
@@ -3,10 +3,16 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <uv.h>
 #include <stdexcept>
+#include <chrono>
 
 #include "BluetoothHciSocket.h"
+
+static uint64_t highResTimeNs() {
+  auto now = std::chrono::steady_clock::now();
+  auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+  return static_cast<uint64_t>(ns);
+}
 
 BluetoothHciSocket::BluetoothHciSocket(const Napi::CallbackInfo& info) :
   Napi::ObjectWrap<BluetoothHciSocket>(info), 
@@ -344,13 +350,13 @@ bool BluetoothHciSocket::kernelConnectWorkArounds(char * data, int length) {
         l2socket_ptr = it_connecting->second;
         l2socket_ptr->disconnect();
         l2socket_ptr->connect();
-        l2socket_ptr->setExpires(uv_hrtime() + L2_CONNECT_TIMEOUT);
+        l2socket_ptr->setExpires(highResTimeNs() + L2_CONNECT_TIMEOUT);
       } else {
         // Create a new L2CAP socket and initiate connection
         bdaddr_t bdaddr_src = {};
         memcpy(bdaddr_src.b, _address, sizeof(bdaddr_src.b));
 
-        uint64_t expires = uv_hrtime() + L2_CONNECT_TIMEOUT;
+        uint64_t expires = highResTimeNs() + L2_CONNECT_TIMEOUT;
 
         l2socket_ptr = std::make_shared<BluetoothHciL2Socket> (
           this, & bdaddr_src, _addressType, & bdaddr_dst, dst_type, expires);
@@ -620,7 +626,7 @@ void BluetoothHciSocket::Cleanup(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();  // Get the current efnvironment
   Napi::HandleScope scope(env);  // Create a handle scope for memory management
 
-  auto now = uv_hrtime();
+  auto now = highResTimeNs();
 
   for (auto it = this->_l2sockets_connecting.cbegin(); it != this->_l2sockets_connecting.cend() /* not hoisted */; /* no increment */) {
     if (now < it->second->getExpires()) {


### PR DESCRIPTION
I was testing bleno with Deno and it seemed to work fine until it threw because it could not find `uv_hrtime`. This is because Deno uses Tokio instead of libuv. This PR replaces the usage of `uv_hrtime` with std chrono.