### PR TITLE
fix(hci): Check stop flag periodically, even without incoming data

### DIFF
--- a/src/BluetoothHciSocket.cpp
+++ b/src/BluetoothHciSocket.cpp
@@ -672,6 +672,17 @@ bool BluetoothHciSocket::EnsureSocket(const Napi::CallbackInfo& info) {
     this->EmitError(info, "socket creation failed");
     return false;
   }
+
+  struct timeval tv = {};
+  
+  memset(&tv, 0, sizeof(tv));
+  tv.tv_sec = 1;
+  tv.tv_usec = 0;
+  
+  // Allow the poll thread to check the stop flag periodically even when no data is incoming
+  if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+    this->EmitError(info, "setsockopt failed for SO_RCVTIMEO");
+  }
   
   this->_socket = fd;
   return true;


### PR DESCRIPTION
Fixes https://github.com/stoprocent/noble/issues/30 and https://github.com/stoprocent/bleno/issues/11.

This adds a read timeout to the HCI Linux socket using `SO_RCVTIMEO` (see [socket(7)](https://man7.org/linux/man-pages/man7/socket.7.html)), allowing the poll thread to check the stop flag even when there is no activity on the socket.

**Alternatives considered:**
- **Immediate socket close** - couldn't guarantee pending commands reach the HCI device
- **Explicit wait for specific response events** - would require significant additional code in both Bleno's and Noble's clean up process

Happy to discuss or elaborate!