### PR TITLE
fix(build): upgrade Docker API version in prebuildify-cross patches t…

### DIFF
--- a/patches/@vweevers+docker-pull+1.1.1.patch
+++ b/patches/@vweevers+docker-pull+1.1.1.patch
@@ -7,7 +7,7 @@ index 67b3e73..bac4a84 100644
    if (!image) throw new Error('Invalid image')
  
 -  var request = docker({host: opts.host, version: opts.version || 'v1.21'})
-+  var request = docker({host: opts.host, version: opts.version || 'v1.24'})
++  var request = docker({host: opts.host, version: opts.version || 'v1.44'})
    var that = new events.EventEmitter()
    var layers = {}
    var progress = {}

--- a/patches/docker-run+3.1.0.patch
+++ b/patches/docker-run+3.1.0.patch
@@ -7,7 +7,7 @@ index ea7fc0d..1f08702 100644
    if (!opts) opts = {}
  
 -  var request = docker(opts.host, {version:'v1.14'})
-+  var request = docker(opts.host, {version:'v1.24'})
++  var request = docker(opts.host, {version:'v1.44'})
    var that = new events.EventEmitter()
    var tty = !!opts.tty
  


### PR DESCRIPTION
…o v1.44

Modern Docker daemons require minimum API version 1.44. The existing patches set v1.24 which is now rejected with "client version 1.24 is too old" errors during ARM cross-compilation in CI.

https://claude.ai/code/session_01FSZYySRpD3pb1fTDVS2jYo