### PR TITLE
fix(ci): use macos-latest for darwin builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,7 @@ jobs:
       matrix:
         include:
           - name: darwin
-            os: macos-13
-            node: x64
+            os: macos-latest
             command: prebuildify
             args: --arch x64+arm64
           - name: win32-x86


### PR DESCRIPTION
macos-13 is a legacy Intel runner. macos-latest now resolves to Apple Silicon (ARM64) which is faster and can natively build the arm64 slice. The x64 node architecture constraint is removed since prebuildify already handles cross-compilation via --arch x64+arm64.

https://claude.ai/code/session_01FSZYySRpD3pb1fTDVS2jYo