### PR TITLE
fix: thread cleanup in destructor and Stop method

### DIFF
--- a/src/BluetoothHciSocket.cpp
+++ b/src/BluetoothHciSocket.cpp
@@ -583,6 +583,11 @@ void BluetoothHciSocket::SetFilter(const Napi::CallbackInfo& info) {
 }
 
 void BluetoothHciSocket::Start(const Napi::CallbackInfo& info) {
+  if (!stopFlag && pollingThread.joinable()) {
+    stopFlag = true;
+    pollingThread.join();
+  }
+
   if (!this->EnsureSocket(info)) {
     return;
   }


### PR DESCRIPTION
Ensure polling thread is properly stopped and joined before cleanup.