### PR TITLE
feat: Add ASUS USB-BT500 (Realtek RTL8761B) support

### DIFF
--- a/lib/usb.js
+++ b/lib/usb.js
@@ -19,6 +19,7 @@ const VENDOR_DEVICE_LIST = [
   { vid: 0x413c, pid: 0x8143 }, // Broadcom BCM20702A0
   { vid: 0x0a12, pid: 0x0001 }, // CSR
   { vid: 0x0b05, pid: 0x17cb }, // ASUS BT400
+  { vid: 0x0b05, pid: 0x190e }, // ASUS USB-BT500 (Realtek RTL8761B)
   { vid: 0x8087, pid: 0x07da }, // Intel 6235
   { vid: 0x8087, pid: 0x07dc }, // Intel 7260
   { vid: 0x8087, pid: 0x0a2a }, // Intel 7265
@@ -277,6 +278,13 @@ BluetoothHciSocket.prototype.onHciEventEndpointData = function (data) {
 
     if (this._mode === 'raw' && buf.length === 6 && (buf.toString('hex') === '0e0401030c00' || buf.toString('hex') === '0e0402030c00')) {
       debug('reset complete');
+      this._isUp = true;
+      this.emit('state', this._isUp);
+    } else if (!this._isUp && this._mode === 'raw' && buf.length > 0 && buf.readUInt8(0) === 0x0e) {
+      // Fallback: accept any Command Complete event as reset acknowledgment.
+      // Some controllers (e.g. Realtek RTL8761B) don't send the standard reset
+      // complete response but the device is functional once past initialization.
+      debug('reset complete (fallback)');
       this._isUp = true;
       this.emit('state', this._isUp);
     }


### PR DESCRIPTION
Add the ASUS USB-BT500 dongle (vid: 0x0b05, pid: 0x190e) to the vendor device list.

Add a fallback in the HCI event handler that accepts any Command Complete event (0x0e) as a reset acknowledgment when the device hasn't initialized yet. The Realtek RTL8761B firmware doesn't send the standard reset complete response, causing the state machine to never reach "poweredOn". Since the only command sent during init is HCI Reset, any Command Complete event at that point must be its response.

Fixes #13

https://claude.ai/code/session_01LxZ52PGtnmHRvx2sPcmpox