### PR TITLE
fix: null _queue race condition in uart.js write()

### DIFF
--- a/lib/uart.js
+++ b/lib/uart.js
@@ -235,7 +235,7 @@ class BluetoothHciSocket extends EventEmitter {
 
   write (data) {
     debug(`Write: ${data.toString('hex')}`);
-    if (this._mode === 'raw' || this._mode === 'user') {
+    if ((this._mode === 'raw' || this._mode === 'user') && this._queue) {
       this._queue.push(data);
     }
   }


### PR DESCRIPTION
bindUser() sets _mode on line 50 but creates _queue on line 71. If write() is called between these two points (e.g. during reconnection), the mode check passes but _queue is still null, causing a crash. Add a null guard for _queue in the write() condition.

https://claude.ai/code/session_01HkebHixb3ASRumcrKYRD8p