### PR TITLE
fix: Update Windows CI runners from windows-2019 to windows-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
             command: prebuildify
             args: --arch x64+arm64
           - name: win32-x86
-            os: windows-2019
+            os: windows-latest
             node: x86
             command: prebuildify
           - name: win32-x64
-            os: windows-2019
+            os: windows-latest
             node: x64
             command: prebuildify
           - name: linux-x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           # arch isn't used and we have no way to use it currently
           - { os: macos-latest, arch: x64 }
           - { os: ubuntu-latest, arch: x64 }
-          - { os: windows-2019, arch: x64 }
+          - { os: windows-latest, arch: x64 }
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
windows-2019 is deprecated on GitHub Actions. Switch build and test workflows to windows-latest.

https://claude.ai/code/session_01HkebHixb3ASRumcrKYRD8p